### PR TITLE
Fix minor typo in student enrollment mailer

### DIFF
--- a/app/views/enrollment_mailer/student_enrollment.html.haml
+++ b/app/views/enrollment_mailer/student_enrollment.html.haml
@@ -1,30 +1,30 @@
-%b 
-  You have enrolled to the course
+%b
+  You have enrolled in the course
 = link_to @enrollment.course, @enrollment.course
 .row
-%b 
+%b
   Enrollment date:
 = @enrollment.created_at
 .row
-%b 
-  Enrollment ID: 
+%b
+  Enrollment ID:
 = @enrollment.slug
 .row
-%b 
+%b
   Course price:
 = number_to_currency(@enrollment.course.price)
 .row
-%b 
+%b
   Price paid:
 = number_to_currency(@enrollment.price)
 .row
-%b 
+%b
   Course instructor:
 = @enrollment.course.user.username
 = mail_to @enrollment.course.user.email, @enrollment.course.user.email
 %p
 After completing the course, you will be entitled to a Certificate of Completion.
 %p
-Regards, 
+Regards,
 .row
 = link_to 'The Corsego team', root_url


### PR DESCRIPTION
Changes student enrollment mailed from "enrolled to the course" to "enrolled in the course" 