### PR TITLE
Add letter_opener_web gem for email preview interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development do
   gem 'rubocop-rails', require: false
   gem 'standard', require: false
   gem 'letter_opener'
+  gem 'letter_opener_web' # web interface for letter_opener
   gem 'rails-erd' # sudo apt-get install graphviz; bundle exec erd
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,11 @@ GEM
       logger (~> 1.6)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -531,6 +536,7 @@ DEPENDENCIES
   invisible_captcha
   jbuilder (~> 2.7)
   letter_opener
+  letter_opener_web
   listen
   minitest (~> 5.0)
   mocha

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   devise_for :users, controllers: {registrations: "users/registrations",
                                    omniauth_callbacks: "users/omniauth_callbacks"}
 


### PR DESCRIPTION
## Summary
Add the `letter_opener_web` gem to provide a web interface for previewing emails in development environments.

## Changes
- Added `letter_opener_web` gem to the development dependencies in Gemfile
- Mounted the LetterOpenerWeb engine at `/letter_opener` route (development only)
- Updated Gemfile.lock with the new gem and its dependencies

## Details
The `letter_opener_web` gem provides a convenient web UI for viewing emails sent during development, complementing the existing `letter_opener` gem. The engine is mounted conditionally to only be available in the development environment, keeping it out of production builds.

Emails can now be previewed by navigating to `http://localhost:3000/letter_opener` in development.

https://claude.ai/code/session_01CcDLy1CE5tXejh63ZCLLRG