### PR TITLE
Add jemalloc buildpack and move webpack-cli to dependencies

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,9 @@
   "stack": "heroku-24",
   "buildpacks": [
     {
+      "url": "https://github.com/gaffneyc/heroku-buildpack-jemalloc.git"
+    },
+    {
       "url": "heroku/nodejs"
     },
     {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "trix": "^2.0.0",
     "webpack": "^5.0.0",
     "webpack-assets-manifest": "^5.2.1",
+    "webpack-cli": "^5.0.0",
     "webpack-merge": "^5.10.0"
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-cli": "^5.0.0",
     "webpack-dev-server": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
This PR improves the application's build configuration and memory management by adding the jemalloc memory allocator and reorganizing webpack dependencies.

## Key Changes
- **Added jemalloc buildpack**: Integrated `heroku-buildpack-jemalloc` to optimize memory allocation and improve performance on Heroku
- **Reorganized webpack dependencies**: Moved `webpack-cli` from `devDependencies` to `dependencies` to ensure it's available in production builds

## Implementation Details
The jemalloc buildpack is added as the first buildpack in the Heroku stack configuration, allowing it to be initialized before other buildpacks (Node.js, Ruby). This ordering is important for proper memory allocator integration.

The webpack-cli dependency change ensures the CLI tools are available during the build process, which may be required for production asset compilation in the Rails asset pipeline integration.

https://claude.ai/code/session_013xMWX55FBWKcX2hpDGeyZe